### PR TITLE
New usb config MICROPY_HW_ENABLE_USB

### DIFF
--- a/mpconfigboard.h
+++ b/mpconfigboard.h
@@ -6,13 +6,8 @@
 #define MICROPY_HW_HAS_SWITCH       (1)		// has 2 buttons KEY0=PE4, KEY1=PE3
 #define MICROPY_HW_HAS_FLASH        (1)
 #define MICROPY_HW_HAS_SDCARD       (0)		// it has a sd scard, but i am not sure what the detect pin is, yet
-#define MICROPY_HW_HAS_MMA7660      (0)
-#define MICROPY_HW_HAS_LIS3DSH      (0)
-#define MICROPY_HW_HAS_LCD          (0)		// has a ILI9341 TFT connector
 #define MICROPY_HW_ENABLE_RNG       (1)
 #define MICROPY_HW_ENABLE_RTC       (1)
-#define MICROPY_HW_ENABLE_TIMER     (1)
-#define MICROPY_HW_ENABLE_SERVO     (0)
 #define MICROPY_HW_ENABLE_DAC       (1)
 #define MICROPY_HW_ENABLE_CAN       (1)
 #define MICROPY_HW_ENABLE_USB       (1)

--- a/mpconfigboard.h
+++ b/mpconfigboard.h
@@ -15,6 +15,7 @@
 #define MICROPY_HW_ENABLE_SERVO     (0)
 #define MICROPY_HW_ENABLE_DAC       (1)
 #define MICROPY_HW_ENABLE_CAN       (1)
+#define MICROPY_HW_ENABLE_USB       (1)
 
 // HSE is 8MHz
 #define MICROPY_HW_CLK_PLLM (8) // divide external clock by this to get 1MHz
@@ -151,5 +152,6 @@
 // 10 SW1 - GND
 
 // USB config
+#define MICROPY_HW_USB_FS (1)
 // #define MICROPY_HW_USB_VBUS_DETECT_PIN (pin_A9)
 // #define MICROPY_HW_USB_OTG_ID_PIN      (pin_A10)

--- a/stm32f4xx_hal_conf.h
+++ b/stm32f4xx_hal_conf.h
@@ -46,8 +46,6 @@
 /* Exported types ------------------------------------------------------------*/
 /* Exported constants --------------------------------------------------------*/
 
-#define USE_USB_FS
-
 /* ########################## Module Selection ############################## */
 /**
   * @brief This is the list of modules to be used in the HAL driver


### PR DESCRIPTION
In the latest version of MicroPython, USB config has been cleaned up and a new config option introduced `MICROPY_HW_ENABLE_USB`, which allows USB to be completely disabled and defaults to off.

This PR adds the `#define` in `mpconfigboard.h` to switch USB back on.

https://github.com/micropython/micropython/commit/5c320bd0b093f44cad19046d84a63e5ed4e7fc87#diff-4a448575fb7cfab8e70659b57c9cb4cc

I've applied this to my [BLACK_F407VE](https://github.com/mcauser/BLACK_F407VE) and [BLACK_F407ZE](https://github.com/mcauser/BLACK_F407ZE) repos.